### PR TITLE
Fix sendgrid email parameter order

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -73,7 +73,12 @@ def send_email(to_email, subject, content):
         from_email = Email("newsletter@thinkwrapper.com")
         to_email = Email(to_email)
         content = Content("text/html", content)
-        mail = Mail(from_email, subject, to_email, content)
+        mail = Mail(
+            from_email=from_email,
+            to_emails=to_email,
+            subject=subject,
+            html_content=content,
+        )
         
         response = sg.client.mail.send.post(request_body=mail.get())
         return response.status_code in [200, 202]


### PR DESCRIPTION
## Summary
- fix parameter order when creating `Mail` for SendGrid

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420543d6208332b8abb3b03ca12af6